### PR TITLE
Amended Vagrant config for virtualbox and forwarded ports

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     devbox.vm.box = "ubuntu/xenial64"
     devbox.vm.hostname = "dev.box"
     devbox.vm.network "private_network", ip: "10.10.10.10"
-    devbox.vm.network "forwarded_port", guest: "80", host: "8000"
     devbox.vm.synced_folder "~/projects", "/home/ubuntu/projects",
       owner: "ubuntu", group: "www-data", mount_options: ["dmode=775,fmode=664"]
   end
@@ -32,8 +31,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.name = "devbox"
     vb.cpus = 2
     vb.customize ["modifyvm", :id, "--memory", "1024"]
-    vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
-    vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
   end
 
   # Workaround for ubuntu/xenial not having /usr/bin/python


### PR DESCRIPTION
Virtualbox configuration parameters were causing devbox to have inconsistent IP set by Vagrant and Virtualbox. As a result mapping IP to hostname in `/etc/hosts` was not working consistently.

Having a private network removes the need to have forwarded ports from guest to host so that configuration was removed from Vagrant too.